### PR TITLE
Update DuckDuckBot IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > Verify that a request is from DuckDuckBot, the Web crawler for DuckDuckGo
 
-This library implements DuckDuckGo's own verification steps [outlined here](https://duckduckgo.com/duckduckbot).
+This library implements DuckDuckGo's own verification steps [outlined here](https://help.duckduckgo.com/duckduckgo-help-pages/results/duckduckbot/).
 
 ## Install
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const dns = require('dns')
 
-// check valid IPs: https://duckduckgo.com/duckduckbot
+// check valid IPs: https://help.duckduckgo.com/duckduckgo-help-pages/results/duckduckbot/
 const DUCKDUCK_VALID_IP = [
   '50.16.241.113',
   '50.16.241.114',

--- a/index.js
+++ b/index.js
@@ -1,7 +1,17 @@
 const dns = require('dns')
 
 // check valid IPs: https://duckduckgo.com/duckduckbot
-const DUCKDUCK_VALID_IP = ['72.94.249.34', '72.94.249.35', '72.94.249.36', '72.94.249.37', '72.94.249.38']
+const DUCKDUCK_VALID_IP = [
+  '50.16.241.113',
+  '50.16.241.114',
+  '50.16.241.117',
+  '50.16.247.234',
+  '52.204.97.54',
+  '52.5.190.19',
+  '54.197.234.188',
+  '54.208.100.253',
+  '23.21.227.69'
+]
 
 function isDuckDuck (ip) {
   return new Promise((resolve, reject) => {

--- a/tests/test.js
+++ b/tests/test.js
@@ -16,7 +16,7 @@ test('should fail with wrong inputs', (t) => {
 
 test('should pass on valid duckduckgo.com crawler ips', (t) => {
   t.plan(3)
-  isDuckDuck('72.94.249.34').then(outcome => t.ok(outcome))
-  isDuckDuck('72.94.249.35').then(outcome => t.ok(outcome))
-  isDuckDuck('72.94.249.36').then(outcome => t.ok(outcome))
+  isDuckDuck('50.16.241.113').then(outcome => t.ok(outcome))
+  isDuckDuck('50.16.241.114').then(outcome => t.ok(outcome))
+  isDuckDuck('50.16.241.117').then(outcome => t.ok(outcome))
 })


### PR DESCRIPTION
This PR updates the following...

 - The list of DuckDuckBot IP addresses to the current list. https://github.com/roccomuso/is-duckduck/commit/be3e0ca6bac08cd371c1ac588ed0f0d3592ca7d3
 - The URL for the DuckDuckBot IP list. https://github.com/roccomuso/is-duckduck/commit/c96b762cac466c044a88a54e972d9e1a231b1a83
 - The list of valid IPs tested in `test.js`. https://github.com/roccomuso/is-duckduck/commit/89c2d2891452b26a41a5ffe6a402e0f11993e90b